### PR TITLE
Fix typo in src/Makefile.am causing Travis to fail

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -213,7 +213,7 @@ BITCOIN_CORE_H += \
   cachemap.h \
   cachemultimap.h \
   dsnotificationinterface.h \
-  flatdatabase.h \
+  flat-database.h \
   governance.h \
   governance-classes.h \
   governance-exceptions.h \


### PR DESCRIPTION
make[1]: *** No rule to make target 'flatdatabase.h', needed by 'distdir'.  Stop.