### PR TITLE
Added md_helper.c to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1403,6 +1403,9 @@ AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
 AC_CONFIG_LINKS([test/functional/test_runner.py:test/functional/test_runner.py])
 AC_CONFIG_LINKS([test/util/bitcoin-util-test.py:test/util/bitcoin-util-test.py])
 AC_CONFIG_LINKS([test/util/rpcauth-test.py:test/util/rpcauth-test.py])
+dnl FXTC BEGIN
+AC_CONFIG_LINKS([src/crypto/md_helper.c:src/crypto/md_helper.c])
+dnl FXTC END
 
 dnl boost's m4 checks do something really nasty: they export these vars. As a
 dnl result, they leak into secp256k1's configure and crazy things happen.


### PR DESCRIPTION
to prevent problems when compiling X16R-related code.