### PR TITLE
[Bug] MN: Fix issue with masternode.conf not loading on daemon start

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 // VELES BEGIN
+#include <masternodeconfig.h>
 #include <veleslogo.h>
 // VELES END
 
@@ -113,6 +114,16 @@ static bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: %s\n", e.what());
             return false;
         }
+
+        // VELES BEGIN
+        // Dash
+        // parse masternode.conf
+        std::string strErr;
+        if(!masternodeConfig.read(strErr)) {
+            fprintf(stderr,"Error reading masternode configuration file: %s\n", strErr.c_str());
+            return false;
+        }
+        // VELES END
 
         // Error out when loose non-argument tokens are encountered on command line
         for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
The issue affected velesd daemon not loading masternode configuration file. One of the effect was that result of RPC command "masternode list-conf" was always empty.