### PR TITLE
MN: Fix an issue with collateral outputs lock

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2804,7 +2804,8 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
             if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(COutPoint(entry.first, i)))
                 continue;
 
-            if (IsLockedCoin(entry.first, i))
+            // VELES edit: fix inconvenience and allow locked collateral
+            if (IsLockedCoin(entry.first, i) && nCoinType != ONLY_MASTERNODE_COLLATERAL)
                 continue;
 
             if (IsSpent(wtxid, i))


### PR DESCRIPTION
When received masternode collateral, and started MN with `masternode start-alias`, wallet returned an error "MasternodeBroadcast::Create -- Could not allocate outpoint". It was an issue with AvailableCoins inherited from FXTC behaving differently than in Dash and skipping the output if already locked.