### PR TITLE
Trivial: Correct the ASCII logo display in help

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -109,7 +109,11 @@ static int AppInitRPC(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     if (argc < 2 || HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
-        std::string strUsage = PACKAGE_NAME " RPC client version " + FormatFullVersion() + "\n";
+        //std::string strUsage = PACKAGE_NAME " RPC client version " + FormatFullVersion() + "\n";
+        // VELES BEGIN
+        std::string strUsage = PACKAGE_NAME " RPC client version " + FormatFullVersion() + 
+            " \"" + CLIENT_VERSION_CODENAME + "\"\n" + strVelesCoreLogoAscii + "\n";
+        // VELES END
         if (!gArgs.IsArgSet("-version")) {
             strUsage += "\n"
                 "Usage:  veles-cli [options] <command> [params]  Send command to " PACKAGE_NAME "\n"

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -143,7 +143,7 @@ static bool AppInit(int argc, char* argv[])
         // Set this early so that parameter interactions go to console
         InitLogging();
         // VELES BEGIN
-        //DisplayBootLogo();
+        DisplayBootLogo();
         // VELES END
         InitParameterInteraction();
         if (!AppInitBasicSetup())

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -961,8 +961,7 @@ void InitLogging()
 // VELES BEGIN
 void DisplayBootLogo()
 {
-    if (LogInstance().m_print_to_console)
-        fprintf(stdout, "%s\n", strVelesCoreLogoAscii.c_str());
+    LogPrintf("\n%s\n", strVelesCoreLogoAscii);
 }
 // VELES END
 


### PR DESCRIPTION
Correct the display of ASCII Veles logo in help messages and daemon log as was in 0.17