### PR TITLE
RPC: Enable backward compatibility for mining-related methods

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -109,6 +109,10 @@ static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 
+// VELES BEGIN
+const static std::string DEFAULT_MINING_ALGO = "scrypt";
+// VELES END
+
 // Dump addresses to banlist.dat every 15 minutes (900s)
 static constexpr int DUMP_BANS_INTERVAL = 60 * 15;
 
@@ -428,10 +432,10 @@ void SetupServerArgs()
     std::vector<std::string> hidden_args = {
         "-dbcrashratio", "-forcecompactdb",
         // GUI args. These will be overwritten by SetupUIArgs for the GUI
-        "-allowselfsignedrootcertificates", "-choosedatadir", "-lang=<lang>", "-min", "-resetguisettings", "-rootcertificates=<file>", "-splash", "-uiplatform"};
+        "-allowselfsignedrootcertificates", "-choosedatadir", "-lang=<lang>", "-min", "-resetguisettings", "-rootcertificates=<file>", "-splash", "-uiplatform",
         // VELES BEGIN
-        // GUI args
-        "-loadcss", "-dumpcss";
+        // Veles-specific GUI args
+        "-loadcss", "-dumpcss"};
         // VELES END
     gArgs.AddArg("-version", "Print version and exit", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-alertnotify=<cmd>", "Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)", false, OptionsCategory::OPTIONS);
@@ -589,8 +593,8 @@ void SetupServerArgs()
     gArgs.AddArg("-blockmintxfee=<amt>", strprintf("Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), false, OptionsCategory::BLOCK_CREATION);
     gArgs.AddArg("-blockversion=<n>", "Override block version to test forking scenarios", true, OptionsCategory::BLOCK_CREATION);
     // VELES BEGIN
-    //gArgs.AddArg("-algo=<algo>", strprintf("Mining algorithm: sha256d, scrypt, lyra2z, x11, x16r (default: sha256)"), false, OptionsCategory::BLOCK_CREATION);
-    gArgs.AddArg("-algo=<algo>", strprintf("Mining algorithm: sha256d, scrypt, lyra2z, x11, x16r (default: scrypt)"), false, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-algo=<algo>", strprintf("Mining algorithm: sha256d, scrypt, lyra2z, x11, x16r (default: %s)", DEFAULT_MINING_ALGO.c_str()), false, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-rpcbackcompatible", strprintf("Support backward compatible syntax for certain RPC methods that miners or mining pools might still depend on (default: %u). Disable this option to keep strict %i.%i RPC syntax. Affected methods: getblocktemplate", DEFAULT_RPC_BACK_COMPATIBLE, CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR), false, OptionsCategory::RPC);
     // VELES END
 
     gArgs.AddArg("-rest", strprintf("Accept public REST requests (default: %u)", DEFAULT_REST_ENABLE), false, OptionsCategory::RPC);
@@ -1260,8 +1264,7 @@ bool AppInitParameterInteraction()
     // FXTC BEGIN
     // algo switch
     // VELES BEGIN
-    //std::string strAlgo = gArgs.GetArg("-algo","sha256");
-    std::string strAlgo = gArgs.GetArg("-algo","scrypt");
+    std::string strAlgo = gArgs.GetArg("-algo", DEFAULT_MINING_ALGO);
     // VELES END
     transform(strAlgo.begin(), strAlgo.end(), strAlgo.begin(), ::tolower);
     if (strAlgo == "sha256d")

--- a/src/net.h
+++ b/src/net.h
@@ -92,6 +92,10 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
+// VELES BEGIN
+static const bool DEFAULT_RPC_BACK_COMPATIBLE = true;
+// VELES END
+
 typedef int64_t NodeId;
 
 struct AddedNodeInfo


### PR DESCRIPTION
Option rpcbackcompatible option enables RPC backward compatibility
for certain methods that miners or mining pools might still depend
on. Currently implemented for getblocktemplate method where the
argument has been changed from optional to required in 0.18.
This method is enabled by defaut, to enforce strict 0.18 syntax
checking, use -rpcbackcompatible=0

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly.

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.

Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
