### PR TITLE
Trivial: Reorganize help categories

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ define(_FXTC_COPYRIGHT_YEAR, 2019)
 dnl VELES END
 define(_COPYRIGHT_HOLDERS,[The %s developers])
 define(_COPYRIGHT_HOLDERS_SUBSTITUTION,[[Veles Core]])
-AC_INIT([Veles Core],m4_join([.], _CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MINOR, _CLIENT_VERSION_REVISION, m4_if(_CLIENT_VERSION_BUILD, [0], [], _CLIENT_VERSION_BUILD))m4_if(_CLIENT_VERSION_RC, [0], [], [rc]_CLIENT_VERSION_RC),[https://github.com/Velescore/veles/issues],[veles],[https://veles.network/])
+AC_INIT([Veles Core],m4_join([.], _CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MINOR, _CLIENT_VERSION_REVISION, m4_if(_CLIENT_VERSION_BUILD, [0], [], _CLIENT_VERSION_BUILD))m4_if(_CLIENT_VERSION_RC, [0], [], [rc]_CLIENT_VERSION_RC),[https://github.com/velescore/veles/issues],[veles],[https://veles.network/])
 AC_CONFIG_SRCDIR([src/validation.cpp])
 AC_CONFIG_HEADERS([src/config/bitcoin-config.h])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -1054,10 +1054,10 @@ UniValue getsuperblockbudget(const JSONRPCRequest& request)
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
-    { "dash",               "gobject",                &gobject,                {"command"}  },
-    { "dash",               "getgovernanceinfo",      &getgovernanceinfo,      {}  },
-    { "dash",               "getsuperblockbudget",    &getsuperblockbudget,    {"index"}  },
-    { "dash",               "voteraw",                &voteraw,                {"masternode-tx-hash", "masternode-tx-index", "governance-hash", "vote-signal", "yes-no-abstain", "time", "vote-sig"}  },
+    { "governance",         "gobject",                &gobject,                {"command"}  },
+    { "governance",         "getgovernanceinfo",      &getgovernanceinfo,      {}  },
+    { "governance",         "getsuperblockbudget",    &getsuperblockbudget,    {"index"}  },
+    { "governance",         "voteraw",                &voteraw,                {"masternode-tx-hash", "masternode-tx-index", "governance-hash", "vote-signal", "yes-no-abstain", "time", "vote-sig"}  },
 };
 
 void RegisterDashGovernanceRPCCommands(CRPCTable &t)

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -957,11 +957,12 @@ UniValue sentinelping(const JSONRPCRequest& request)
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
-    { "dash",               "masternode",             &masternode,             {"command"}  },
-    { "dash",               "masternodelist",         &masternodelist,         {"mode", "filter"}  },
-    { "dash",               "masternodebroadcast",    &masternodebroadcast,    {"command"}  },
-    { "dash",               "getpoolinfo",            &getpoolinfo,            {}  },
-    { "dash",               "sentinelping",           &sentinelping,           {"version"}  },
+  //  Veles Core: Category renamed from Dash to Masternode
+    { "masternode",         "masternode",             &masternode,             {"command"}  },
+    { "masternode",         "masternodelist",         &masternodelist,         {"mode", "filter"}  },
+    { "masternode",         "masternodebroadcast",    &masternodebroadcast,    {"command"}  },
+    { "masternode",         "getpoolinfo",            &getpoolinfo,            {}  },
+    { "masternode",         "sentinelping",           &sentinelping,           {"version"}  },
 #ifdef ENABLE_WALLET
 // FXTC TODO:    { "dash",               "privatesend",            &privatesend,            {"command"}  },
 #endif

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -342,7 +342,7 @@ static UniValue gethalvingstatus(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() != 0)    // || (strMode != "basic" && strMode != "full" && strMode != "dev"))
         throw std::runtime_error(
-            "gethalvingstatus                   *** NEW: Experimental ***\n"    // ( \"mode\" )
+            "gethalvingstatus\n"    // ( \"mode\" )
             "\nReturns a json object containing an information related to block reward halving. A halving epoch is time between\n"
             "the start and end of block subsidy halving interval, where maximum block reward is the same for all the blocks\n"
             "within the epoch. If not enough coins are mined during the epoch, the halving will not occur and the current epoch\n"
@@ -481,7 +481,6 @@ static UniValue getmultialgostatus(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
             RPCHelpMan{"getmultialgostatus",
-            //"\n*** Experimental: Use at your own risk, might be a subject to change any time. ***\n"
             "\nReturns a json object containing information related to multi-algo mining.",
             {},
             RPCResult{

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -789,10 +789,9 @@ static const CRPCCommand commands[] =
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
 
     // Dash
-    // Veles Core: Category renamed from Dash to Masternodes
-    { "masternodes",        "mnsync",                 &mnsync,                 {"status-next-reset"}  },
-    // Doesn't fit into the mn category
-    { "dash",               "spork",                  &spork,                  {"name", "value"}  },
+    // Veles Core: Reorged category names
+    { "masternode",        "mnsync",                 &mnsync,                 {"status-next-reset"}  },
+    { "governance",        "spork",                  &spork,                  {"name", "value"}  },
     //
 };
 // clang-format on


### PR DESCRIPTION
- Better organize help categories as been in 0.17 version
- Remove Experimental warning from gethalvingstatus help
- Update github link to lowercase in -version help message