### PR TITLE
MN: Backport collateral change to 500 VLS

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,10 +81,11 @@ public:
         consensus.nMinimumSubsidy = 0.00100000 * COIN;
         consensus.nMasternodeMinimumConfirmations = 15;
 	    consensus.nMasternodePaymentsStartBlock = 50;
-        consensus.nMasternodeCollateralMinimum = 2000;
-        consensus.nMasternodeCollateralMaximum = 2000;
 //      consensus.nMasternodePaymentsIncreaseBlock = 50;    // In Veles is VCIP01 block
         consensus.nMasternodePaymentsIncreasePeriod = 365 * 576 * 5; // 5 years, activated with VCIP01
+        consensus.nMasternodeCollateralMinimum = 2000; // starting MN collateral
+        consensus.nMasternodeCollateralMaximum = 2000; // MN collateral at infinity
+        consensus.nMasternodeCollateral201908  = 500;  // MN collateral
         // VELES BEGIN
         consensus.nMasternodePaymentsStartPercent =  5;     // at VCIP01 this should equal to approx same VLS amount as before
         consensus.nMasternodePaymentsFinalPercent =  60;    // will be reached in ca 5 years
@@ -247,6 +248,7 @@ public:
         consensus.nMasternodePaymentsIncreasePeriod = 25;
         consensus.nMasternodeCollateralMinimum = 10; // starting MN collateral
         consensus.nMasternodeCollateralMaximum = 1000; // MN collateral at infinity
+        consensus.nMasternodeCollateral201908  = 500; // MN collateral
         // VELES BEGIN
         consensus.nMasternodePaymentsStartPercent =  5;
         consensus.nMasternodePaymentsFinalPercent =  60; // will be reached in ca 5 yrs
@@ -392,6 +394,7 @@ public:
         consensus.nMasternodePaymentsIncreasePeriod = 10;
         consensus.nMasternodeCollateralMinimum = 1; // starting MN collateral
         consensus.nMasternodeCollateralMaximum = 100; // MN collateral at infinity
+        consensus.nMasternodeCollateral201908  = 500; // MN collateral
         // VELES BEGIN
         consensus.nMasternodePaymentsStartPercent =  5;
         consensus.nMasternodePaymentsFinalPercent =  60; // will be reached in ca 5 yrs

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -72,6 +72,7 @@ struct Params {
     int nMasternodePaymentsIncreasePeriod; // in blocks
     int nMasternodeCollateralMinimum; // in coins
     int nMasternodeCollateralMaximum; // in coins
+    int nMasternodeCollateral201908;  // in coins
     // VELES BEGIN
     int nMasternodePaymentsStartPercent;
     int nMasternodePaymentsFinalPercent;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -134,30 +134,26 @@ CMasternode::CollateralStatus CMasternode::CheckCollateral(const COutPoint& outp
     return COLLATERAL_OK;
 }
 
-// FXTC BEGIN
+// VELES BEGIN
 bool CMasternode::CollateralValueCheck(int nHeight, CAmount TxValue)
 {
-    CAmount MNCollateral = CollateralValue(nHeight);
+    if (TxValue == CollateralValue(nHeight))
+        return true;
+
+    if (nHeight >= 240000)
+        return false;
 
     CAmount MinCollateral = Params().GetConsensus().nMasternodeCollateralMinimum * COIN;
     CAmount MaxCollateral = Params().GetConsensus().nMasternodeCollateralMaximum * COIN;
 
-    return (TxValue >= MinCollateral && TxValue >= 0.999 * MNCollateral && TxValue <= 1.001 * MNCollateral && TxValue <= MaxCollateral);
+    return (TxValue >= MinCollateral && TxValue <= MaxCollateral);
 }
 
 CAmount CMasternode::CollateralValue(int nHeight)
 {
-    // Maximum 100000 FTC in infinity, starting 1000 FTC
-
-    int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod;
-    CAmount MinCollateral = Params().GetConsensus().nMasternodeCollateralMinimum;
-    CAmount MaxCollateral = Params().GetConsensus().nMasternodeCollateralMaximum;
-
-    CAmount MnCollateral = (MaxCollateral - (MaxCollateral - MinCollateral) * (100.00 * nMNPIPeriod / (1.00 * nHeight + 100.00 * nMNPIPeriod ))) * COIN;
-
-    return MnCollateral;
+    return Params().GetConsensus().nMasternodeCollateral201908 * COIN;
 }
-//
+// VELES END
 
 void CMasternode::Check(bool fForce)
 {


### PR DESCRIPTION
Backport masternode collateral change from 2000 VLS to 500 VLS, forced at block 240k, to the 0.17 branch.